### PR TITLE
Resolve pip install test failure

### DIFF
--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -19,7 +19,7 @@ describe 'tilequeue::install' do
   end
 
   it 'should python_pip install the requirements file' do
-    expect(chef_run).to install_python_pip '-U -r /home/ubuntu/.chef/cache/tilequeue-pip-requirements.txt'
+    expect(chef_run).to install_python_pip "-U -r #{Chef::Config[:file_cache_path]}/tilequeue-pip-requirements.txt"
   end
 
   %w(config.yaml logging.conf).each do |f|


### PR DESCRIPTION
Use the file_cache_path config option to generate the path used for the
pip requirements file.