### PR TITLE
Fix recipe after adding EDTF library dependency.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ default[:tilequeue][:logging_file]                              = 'logging.conf'
 
 default[:tilequeue][:install_method]                            = 'pip_requirements'
 default[:tilequeue][:pip_requirements_location]                 = "#{node[:tilequeue][:cfg_path]}/pip-requirements.txt"
+default[:tilequeue][:pip_requirements_extra_location]           = "#{node[:tilequeue][:cfg_path]}/pip-requirements_extra.txt"
 
 default[:tilequeue][:revision][:tilestache] = 'integration-1'
 default[:tilequeue][:revision][:mapbox_vector_tile] = 'master'
@@ -32,7 +33,8 @@ default[:tilequeue][:pip_requirements] = %w(
   Werkzeug==0.9.6
   wsgiref==0.1.2
 )
-default[:tilequeue][:pip_requirements] += [
+
+default[:tilequeue][:pip_requirements_extra] = [
   "git+https://github.com/mapzen/TileStache@#{node[:tilequeue][:revision][:tilestache]}#egg=TileStache",
   "git+https://github.com/mapzen/mapbox-vector-tile@#{node[:tilequeue][:revision][:mapbox_vector_tile]}#egg=mapbox-vector-tile",
   "git+https://github.com/mapzen/tilequeue@#{node[:tilequeue][:revision][:tilequeue]}#egg=tilequeue"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,11 +17,14 @@ git node[:tilequeue][:vector_datasource][:path] do
   revision node[:tilequeue][:vector_datasource][:revision]
 end
 
-# generate a pip requirements file for consistent python package
-# versions
+# pip install base requirements
 file node[:tilequeue][:pip_requirements_location] do
   content node[:tilequeue][:pip_requirements].join("\n")
 end
-
-# install python packages from requirements file
 python_pip "-U -r #{node[:tilequeue][:pip_requirements_location]}"
+
+# pip install extras
+file node[:tilequeue][:pip_requirements_extra_location] do
+  content node[:tilequeue][:pip_extra_requirements].join("\n")
+end
+python_pip "-U -r #{node[:tilequeue][:pip_requirements_extra_location]}"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -25,6 +25,6 @@ python_pip "-U -r #{node[:tilequeue][:pip_requirements_location]}"
 
 # pip install extras
 file node[:tilequeue][:pip_requirements_extra_location] do
-  content node[:tilequeue][:pip_extra_requirements].join("\n")
+  content node[:tilequeue][:pip_requirements_extra].join("\n")
 end
 python_pip "-U -r #{node[:tilequeue][:pip_requirements_extra_location]}"

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -18,6 +18,7 @@ end
   libpq-dev
   python-pip
   python-pil
+  libjpeg-dev
 ).each do |p|
   package p
 end


### PR DESCRIPTION
- break pip install into two part to avoid missing dependency chain
- add libjpeg-dev dependency (Pillow)

Note that the root cause is that the `edtf` Python package imports itself to provide package info, which gets run before its dependencies are installed. The author has [fixed it](https://github.com/ixc/python-edtf/commit/fffa4d209899853217e38c341e02878bd512f0ce), but as yet there's no release on PyPi.

Thanks to @heffergm for doing most of the work.