### PR TITLE
Add configuration for retrying WOF HTTP fetches.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -113,6 +113,9 @@ default[:tilequeue][:wof][:meta_url][:neighbourhoods]           = 'https://githu
 default[:tilequeue][:wof][:meta_url][:microhoods]               = 'https://github.com/whosonfirst/whosonfirst-data/raw/master/meta/wof-microhood-latest.csv'
 default[:tilequeue][:wof][:meta_url][:macrohoods]               = 'https://github.com/whosonfirst/whosonfirst-data/raw/master/meta/wof-macrohood-latest.csv'
 default[:tilequeue][:wof][:data_prefix_url]                     = 'http://whosonfirst.mapzen.com/data'
+# this defaults to not retrying at all, please override in stack.json or your
+# own site recipes.
+default[:tilequeue][:wof][:max_retries]                         = 0
 
 default[:tilequeue][:wof][:postgresql][:host]                   = node[:tilequeue][:postgresql][:host]
 default[:tilequeue][:wof][:postgresql][:dbname]                 = node[:tilequeue][:postgresql][:dbname]

--- a/templates/default/tilequeue-config.yaml.erb
+++ b/templates/default/tilequeue-config.yaml.erb
@@ -66,6 +66,7 @@ wof:
   microhoods-meta-url: <%= node[:tilequeue][:wof][:meta_url][:microhoods] %>
   macrohoods-meta-url: <%= node[:tilequeue][:wof][:meta_url][:macrohoods] %>
   data-prefix-url: <%= node[:tilequeue][:wof][:data_prefix_url] %>
+  max-retries: <%= node[:tilequeue][:wof][:max_retries] %>
   postgresql:
     host: <%= node[:tilequeue][:wof][:postgresql][:host] %>
     port: 5432


### PR DESCRIPTION
The optional configuration parameter for the maximum number of retries that the WOF code should attempt when downloading files over HTTP was added in [this PR](https://github.com/mapzen/tilequeue/pull/61) to address [this issue](https://github.com/mapzen/tilequeue/issues/60). I've defaulted it to zero here, with the intention that it be overridden as appropriate by `stack.json` and/or any downstream recipes.

@heffergm could you review, please?
